### PR TITLE
Corrected comment in market.py

### DIFF
--- a/nempy/markets.py
+++ b/nempy/markets.py
@@ -1278,7 +1278,7 @@ class SpotMarket:
 
         On a unit basis for generators they take the form of:
 
-            Energy dispatch + Regulation lower target <= initial output - ramp down rate * (dispatch interval / 60)
+            Energy dispatch - Regulation lower target >= initial output - ramp down rate * (dispatch interval / 60)
 
         Examples
         --------


### PR DESCRIPTION
Joint ramping constraint equation for lower regulation service is corrected as per AEMO FCAS model documentation.