### PR TITLE
Fix for compatibility with pandas 1.5.x

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -15,13 +15,17 @@ jobs:
     # Matrix testing to test across OSs and Python versions
     # Fail-fast: fail the entire job as soon as anything fails
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         version-constraints:
           - ""
           - "'pandas==1.*' 'numpy==1.*'"
+	exclude:
+          - os: macos-latest
+            python-version: '3.13'
+            version-constraints: "'pandas==1.*' 'numpy==1.*'"
 
       # Necessary for poetry & Windows
     defaults:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -15,10 +15,10 @@ jobs:
     # Matrix testing to test across OSs and Python versions
     # Fail-fast: fail the entire job as soon as anything fails
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
         version-constraints:
           - ""
           - "'pandas==1.*' 'numpy==1.*'"

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -19,9 +19,9 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-	version-constraints:
-	 - ""
-	 - "'pandas==1.*' 'numpy==1.*'"
+        version-constraints:
+          - ""
+          - "'pandas==1.*' 'numpy==1.*'"
 
       # Necessary for poetry & Windows
     defaults:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -30,10 +30,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
 
@@ -61,10 +61,10 @@ jobs:
     steps:
       # Checkout repo
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # Install uv with cache
       - name: Install the latest version of uv
-        uses: astral-sh/setup-uv@v3
+        uses: astral-sh/setup-uv@v6
         with:
           enable-cache: true
       # Sync dependencies

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -22,7 +22,7 @@ jobs:
         version-constraints:
           - ""
           - "'pandas==1.*' 'numpy==1.*'"
-	exclude:
+        exclude:
           - os: macos-latest
             python-version: '3.13'
             version-constraints: "'pandas==1.*' 'numpy==1.*'"

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -32,6 +32,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
       - name: Install the latest version of uv
         uses: astral-sh/setup-uv@v6
         with:

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -15,7 +15,7 @@ jobs:
     # Matrix testing to test across OSs and Python versions
     # Fail-fast: fail the entire job as soon as anything fails
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -15,7 +15,7 @@ jobs:
     # Matrix testing to test across OSs and Python versions
     # Fail-fast: fail the entire job as soon as anything fails
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
@@ -23,11 +23,14 @@ jobs:
           - ""
           - "'pandas==1.*' 'numpy==1.*'"
         exclude:
-          - os: macos-latest
-            python-version: '3.13'
+          # pandas 1.x is not compatible python 3.13
+          - python-version: "3.13"
             version-constraints: "'pandas==1.*' 'numpy==1.*'"
+          # uv run segfaults for windows on python 3.13
+          - os: "windows-latest"
+            python-version: '3.13'
 
-      # Necessary for poetry & Windows
+    # Necessary for Windows
     defaults:
       run:
         shell: bash

--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -19,6 +19,10 @@ jobs:
       matrix:
         os: ["ubuntu-latest", "macos-latest", "windows-latest"]
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+	version-constraints:
+	 - ""
+	 - "'pandas==1.*' 'numpy==1.*'"
+
       # Necessary for poetry & Windows
     defaults:
       run:
@@ -35,6 +39,11 @@ jobs:
 
       - name: Sync dependencies
         run: uv sync
+
+      - name: Resync with restricted versions
+        if: ${{ matrix.version-constraints != '' }}
+        run: |
+          uv pip install ${{ matrix.version-constraints }} --reinstall --strict
 
       - name: Run tests
         run: uv run --frozen pytest tests src -ra --doctest-modules

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 dependencies = [
     "mip==1.16rc0",
-    "pandas>=2.2.2",
+    "pandas>=1.5",
     "xmltodict==0.12.0",
     "requests>=2.0.0",
 ]

--- a/src/nempy/markets.py
+++ b/src/nempy/markets.py
@@ -3167,7 +3167,7 @@ class SpotMarket:
             df = df.iloc[3:, :]
             return df
 
-        vars_to_remove = vars.groupby(['interconnector', 'link'], as_index=False).apply(not_closest_three, include_groups=False)
+        vars_to_remove = vars.groupby(['interconnector', 'link'], as_index=False)[['distance', 'variable_id']].apply(not_closest_three)
         si.disable_variables(vars_to_remove.loc[:, ['variable_id']])
 
     def get_constraint_set_names(self):

--- a/src/nempy/spot_market_backend/solver_interface.py
+++ b/src/nempy/spot_market_backend/solver_interface.py
@@ -114,26 +114,24 @@ class InterfaceToSolver:
 
         """
 
-        # Function that adds sets to mip model.
-        def add_sos_vars(sos_group):
-            self.mip_model.add_sos(list(zip(sos_group['vars'], sos_group[position_column])), 2)
-
         # For each variable_id get the variable object from the mip model
         sos_variables['vars'] = sos_variables['variable_id'].apply(lambda x: self.variables[x])
+
         # Break up the sets based on their id and add them to the model separately.
-        sos_variables.groupby(sos_id_columns).apply(add_sos_vars, include_groups=False)
+        for _, sos_group in sos_variables.groupby(sos_id_columns):
+            self.mip_model.add_sos(list(zip(sos_group['vars'], sos_group[position_column])), 2)
+
         # This is a hack to make sure mip knows there are binary constraints.
         self.mip_model.add_var(var_type=BINARY, obj=0.0)
 
     def add_sos_type_1(self, sos_variables):
-        # Function that adds sets to mip model.
-        def add_sos_vars(sos_group):
-            self.mip_model.add_sos(list(zip(sos_group['vars'], [1.0 for i in range(len(sos_variables['vars']))])), 1)
-
         # For each variable_id get the variable object from the mip model
         sos_variables['vars'] = sos_variables['variable_id'].apply(lambda x: self.variables[x])
+
         # Break up the sets based on their id and add them to the model separately.
-        sos_variables.groupby('sos_id').apply(add_sos_vars)
+        for _, sos_group in sos_variables.groupby('sos_id'):
+            self.mip_model.add_sos(list(zip(sos_group['vars'], [1.0 for i in range(len(sos_variables['vars']))])), 1)
+
         # This is a hack to make mip knows there are binary constraints.
         self.mip_model.add_var(var_type=BINARY, obj=0.0)
 

--- a/tests/test_markets.py
+++ b/tests/test_markets.py
@@ -55,8 +55,14 @@ def test_one_region_energy_market():
         'dispatch': [40.0, 20.0]
     })
 
+    expected_region_dispatch_summary = pd.DataFrame({
+        'region': ['NSW'],
+        'dispatch': [60.0],
+    })
+
     assert_frame_equal(market.get_energy_prices(), expected_prices)
     assert_frame_equal(market.get_unit_dispatch(), expected_dispatch)
+    assert_frame_equal(market.get_region_dispatch_summary(), expected_region_dispatch_summary)
 
 
 def test_two_region_energy_market():
@@ -111,8 +117,14 @@ def test_two_region_energy_market():
         'dispatch': [60.0, 80.0]
     })
 
+    expected_region_dispatch_summary = pd.DataFrame({
+        'region': ['NSW', 'VIC'],
+        'dispatch': [60.0, 80.0],
+    })
+
     assert_frame_equal(market.get_energy_prices(), expected_prices)
     assert_frame_equal(market.get_unit_dispatch(), expected_dispatch)
+    assert_frame_equal(market.get_region_dispatch_summary(), expected_region_dispatch_summary)
 
 
 def test_one_interconnector():
@@ -204,9 +216,18 @@ def test_one_interconnector():
         'losses': [(90.0/0.975) * 0.05]
     })
 
+    expected_region_dispatch_summary = pd.DataFrame({
+        'region': ['NSW', 'VIC'],
+        'dispatch': [94.615385, 0.0],
+        'inflow': [-92.307692, 92.307692],
+        'transmission_losses': [0.0, 0.0],
+        'interconnector_losses': [2.307692, 2.307692],
+    })
+
     assert_frame_equal(market.get_energy_prices(), expected_prices)
     assert_frame_equal(market.get_unit_dispatch(), expected_dispatch)
     assert_frame_equal(market.get_interconnector_flows(), expected_interconnector_flow)
+    assert_frame_equal(market.get_region_dispatch_summary(), expected_region_dispatch_summary)
 
 
 def test_one_region_energy_and_raise_regulation_markets():


### PR DESCRIPTION
Addresses https://github.com/UNSW-CEEM/nempy/issues/36
- relaxes version constraint for pandas to include 1.5.x
   - avoid using `groupby(...).apply(..., include_groups=False)`
- extend tests to cover get_region_dispatch_summary
  - this was mainly to check that some other groupby statements weren't producing the pandas DeprecationWarning related to this include_groups keyword added in pandas 2.x
 - fix 2 exception messages that weren't passing enough arguments to str.format 
  
 Test workflow changes:
 - Update test matrix to include testing with pandas 1.x + numpy 1.x
 - Adding setup-python action to fix issue in macos-latest builds where uv would always use python3.13 (no matter what python-version was enabled)
 - Dropping python 3.8 testing since it is past EOL
 - Adding python 3.13 testing (with a few excludes to avoid unrelated build failures)